### PR TITLE
Fix for build

### DIFF
--- a/src/blezz.c
+++ b/src/blezz.c
@@ -32,8 +32,8 @@
 #include <unistd.h>
 
 #include <rofi/helper.h>
-#include <rofi/mode-private.h>
 #include <rofi/mode.h>
+#include <rofi/mode-private.h>
 #include <rofi/rofi-icon-fetcher.h>
 
 G_MODULE_EXPORT Mode mode;


### PR DESCRIPTION
Hi Dave, I hope you've been well :heart:

As noted in #3, `rofi/mode-private` must go after `rofi/mode` to build successfully